### PR TITLE
streamlink 添加403状态码时，上传请求数据功能

### DIFF
--- a/src/streamlink/exceptions.py
+++ b/src/streamlink/exceptions.py
@@ -57,6 +57,9 @@ class StreamError(StreamlinkError):
 class HTTPStatusCode403Error(StreamlinkError):
     """Stream return 403 status code, raise 403 error"""
 
+    def __init__(self, error):
+        self.error = error
+
 
 __all__ = ["StreamlinkError", "PluginError", "NoPluginError",
            "NoStreamsError", "StreamError", "HTTPStatusCode403Error", ]

--- a/src/streamlink/plugin/api/http_session.py
+++ b/src/streamlink/plugin/api/http_session.py
@@ -160,7 +160,7 @@ class HTTPSession(Session):
                 # LJQ: 403状态码直接抛出异常，不再继续重试 BLOCK{
                 # print(f'{res.status_code}  {res.request.method}  {res.elapsed.total_seconds():.3f} s  {res.headers.get("Content-Length", 0) or len(res.content)} bytes  {res.url}')
                 if res.status_code == 403:
-                    raise HTTPStatusCode403Error(url)
+                    raise HTTPStatusCode403Error(res)
                 # LJQ: BLOCK}
 
                 if raise_for_status and res.status_code not in acceptable_status:

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -59,6 +59,7 @@ class Streamlink:
             "rtmp-timeout": 60.0,
             "rtmp-rtmpdump": is_win32 and "rtmpdump.exe" or "rtmpdump",
             "rtmp-proxy": None,
+            "stream-segment-upload-403-uri": None,
             "stream-segment-attempts": 3,
             "stream-segment-threads": 1,
             "stream-segment-timeout": 10.0,
@@ -229,6 +230,8 @@ class Streamlink:
 
         mux-subtitles            (bool) Mux available subtitles into the
                                  output stream.
+
+        stream-segment-upload-403-uri  (str) URI for uploading request data when HTTP status code equal 403
 
         stream-segment-attempts  (int) How many attempts should be done
                                  to download each segment, default: ``3``.

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -146,7 +146,6 @@ class HLSStreamWriter(SegmentedStreamWriter):
         try:
             request_params = self.create_request_params(sequence)
 
-            # LJQ: TODO: upload 403
             return self.session.http.get(sequence.segment.uri,
                                          stream=(self.stream_data
                                                  and not sequence.segment.key),

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1069,6 +1069,28 @@ def build_parser():
         Default is 60.0.
         """
     )
+    # LJQ: add argument, stream-segment-upload-403-uri
+    transport.add_argument(
+        "--stream-segment-upload-403-uri",
+        metavar="URI",
+        type=str,
+        help="""
+            URI is going to upload the data (e.g. url and headers) of network request when HTTP status code equal 403.
+
+            URI can be templated using the following variables, which will be
+            replaced with its respective part from the source segment URI:
+
+              {url} {scheme} {netloc} {path} {query}
+
+            Examples:
+
+              --stream-segment-upload-403-uri base64("https://example.com/hls/upload")
+              --stream-segment-upload-403-uri base64("{scheme}://1.2.3.4{path}{query}")
+              --stream-segment-upload-403-uri base64("{scheme}://{netloc}/custom/path/to/upload")
+
+            Default is None and it doesn't work.
+            """
+    )
     transport.add_argument(
         "--stream-segment-attempts",
         type=num(int, min=0),

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -829,6 +829,10 @@ def setup_options():
     if args.rtmp_timeout:
         streamlink.set_option("rtmp-timeout", args.rtmp_timeout)
 
+    # LJQ: add stream-segment-upload-403-uri
+    if args.stream_segment_upload_403_uri:
+        streamlink.set_option("stream-segment-upload-403-uri", args.stream_segment_upload_403_uri)
+
     if args.stream_segment_attempts:
         streamlink.set_option("stream-segment-attempts", args.stream_segment_attempts)
 


### PR DESCRIPTION
streamlink 添加403状态码时，上传请求数据功能
上传接口参数 --stream-segment-upload-403-uri
默认为None，不上传。