### PR TITLE
plugins.hls: 修复name_fmt引发的请求报错缺陷

### DIFF
--- a/src/streamlink/plugins/hls.py
+++ b/src/streamlink/plugins/hls.py
@@ -46,6 +46,8 @@ class HLSPlugin(Plugin):
         log.debug("URL={0}; params={1}".format(urlnoproto, params))
         streams = HLSStream.parse_variant_playlist(self.session, urlnoproto, **params)
         if not streams:
+            # LJQ: 删除多余字段name_fmt,此字段会导致HTTPStream进行网络请求时报错.
+            params.pop('name_fmt', None)
             return {"live": HLSStream(self.session, urlnoproto, **params)}
         else:
             return streams

--- a/src/streamlink/utils/named_pipe.py
+++ b/src/streamlink/utils/named_pipe.py
@@ -17,6 +17,9 @@ log = logging.getLogger(__name__)
 _lock = threading.Lock()
 _id = 0
 
+# LJQ: 删除/tmp目录下所有1天前、未访问、以streamlinkpipe-开头的fifo文件
+os.system(f'find {tempfile.gettempdir()}/streamlinkpipe-* -type p -atime +1 -print0 |xargs -0 rm -rf')
+
 
 class NamedPipeBase(abc.ABC):
     path: Path


### PR DESCRIPTION
错误示例: streamlink "hls://live.tv247.club/live/cnbc.m3u8 name_fmt=\"{bitrate}\"" best --stream-sorting-excludes ">2000k" --http-header User-Agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.69 Safari/537.36" --http-header Origin="http://tv247.us" --http-header Referer="http://tv247.us/"