### PR TITLE
修复600及以上HTTP状态码无法停止出流缺陷.

### DIFF
--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -105,7 +105,7 @@ class HLSStreamWriter(SegmentedStreamWriter):
                 token = self.session.cache.get(key_uri)
                 if not token:
                     res = self.session.http.get(key_uri, exception=StreamError,
-                                                retries=self.retries,
+                                                retries=self.retries, dont_report=True,
                                                 **self.reader.request_params)
                     token = self.session.http.json(res)
                     self.session.cache.set(key_uri, token, expires=self.session.options.get('hls-token-period'))
@@ -286,7 +286,7 @@ class HLSStreamWorker(SegmentedStreamWorker):
                 token = self.session.cache.get(key_uri)
                 if not token:
                     res = self.session.http.get(key_uri, exception=StreamError,
-                                                retries=self.playlist_reload_retries,
+                                                retries=self.playlist_reload_retries, dont_report=True,
                                                 **self.reader.request_params)
                     token = self.session.http.json(res)
                     self.session.cache.set(key_uri, token, expires=self.session.options.get('hls-token-period'))

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1407,11 +1407,14 @@ def build_parser():
     http.add_argument(
         "--error-http-status-codes",
         type=comma_list,
-        default=[403, 404],
+        default=[403,],
         help="""
                 Error HTTP status codes that are used to exit the program or stop retrying request.
-
-                Default is [403, 404].
+                Support HTTP status codes range, `T` is the separator
+                `600T700` means 600 to 700 are Error HTTP status codes;
+                `600T` means greater than 600 are Error HTTP status codes;
+                `T700` means less than 700 are Error HTTP status codes;
+                Default is [403,].
                 """
     )
 


### PR DESCRIPTION
--error-http-status-codes 修复600及以上HTTP状态码无法停止出流缺陷. 支持范围报错,T为分隔符,如600T700表示600<=HTTP状态码<700时报错