### PR TITLE
重试最大次数依旧超时,直接退出拉流程序

### DIFF
--- a/src/streamlink/plugin/api/http_session.py
+++ b/src/streamlink/plugin/api/http_session.py
@@ -294,7 +294,7 @@ class HTTPSession(Session):
                         raise err
 
                 if retries >= total_retries:
-                    err = exception(f"Unable to open URL: {url} ({rerr})")
+                    err = HTTPStatusCodesError(f"Unable to open URL: {url} ({rerr})")
                     err.err = rerr
                     raise err
                 retries += 1

--- a/src/streamlink/stream/segmented.py
+++ b/src/streamlink/stream/segmented.py
@@ -221,7 +221,7 @@ class SegmentedStreamWriter(Thread):
                 except futures.CancelledError:
                     break
                 except HTTPStatusCodesError as e:
-                    log.error(f"Failed to open segment {segment.num}: {e}")
+                    log.error(f"Failed to open segment: {e}")
                     # stop all waiting segments to request
                     self.futures.queue.clear()
                     # stop reloading playlist


### PR DESCRIPTION
重试最大次数依旧超时,直接退出拉流程序